### PR TITLE
Fix invalid character

### DIFF
--- a/enjo-app/source/Config.js
+++ b/enjo-app/source/Config.js
@@ -259,7 +259,7 @@ enyo.kind({
 	},
 	
 	handleHelpSelect: function(inSender, inEvent) {
-		if((this._ui == "full") || (this._helpOn == true))
+		if((this._ui == "full") || (this._helpOn == true))
 			this.doSelect(inSender.name, this._help[inSender.name]);
 	},
 


### PR DESCRIPTION
Fixing: Sep 03 13:11:33 mako LunaWebAppManager[31316]: file:///usr/palm/applications/org.webosinternals.tweaks/source/Config.js:262: JS ERROR: ReferenceError: Can't find variable: Â
